### PR TITLE
enabled document authoring features

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,6 +1,6 @@
 mountpoints:
   /:
-    url: https://drive.google.com/drive/folders/1jB3TTvp0O_J-SnnHyc5ktkPJpsPv7OnV
+    url: https://content.da.live/atf-z/atf-aem-test/
     type: markup
 
 folders:

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,15 +1,5 @@
 {
-  "project": "Boilerplate",
-  "plugins": [
-    {
-      "id": "cif",
-      "title": "Commerce",
-      "environments": [
-        "edit"
-      ],
-      "url": "https://main--aem-boilerplate-commerce--hlxsites.aem.live/tools/picker/dist/index.html",
-      "isPalette": true,
-      "paletteRect": "top: 54px; left: 5px; bottom: 5px; width: 300px; height: calc(100% - 59px); border-radius: var(--hlx-sk-button-border-radius); overflow: hidden; resize: horizontal;"
-    }
-  ]
+  "project": "ATF AEM Test",
+  "editUrlLabel": "Document Authoring",
+  "editUrlPattern": "https://da.live/#/atf-z/atf-aem-test"
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](https://github.com/atf-z/atf-aem-test/issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Enabled https://da.live/ integration

Test URLs:

Before: https://main--atf-aem-test--atf-z.aem.live/
After: https://enable-document-authoring--atf-aem-test--atf-z.aem.live/