### PR TITLE
Disable document authoring / Revert to file storage mode

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,6 +1,6 @@
 mountpoints:
   /:
-    url: https://content.da.live/atf-z/atf-aem-test/
+    url: https://drive.google.com/drive/folders/1jB3TTvp0O_J-SnnHyc5ktkPJpsPv7OnV
     type: markup
 
 folders:

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,5 +1,15 @@
 {
-  "project": "ATF AEM Test",
-  "editUrlLabel": "Document Authoring",
-  "editUrlPattern": "https://da.live/#/atf-z/atf-aem-test"
+  "project": "Boilerplate",
+  "plugins": [
+    {
+      "id": "cif",
+      "title": "Commerce",
+      "environments": [
+        "edit"
+      ],
+      "url": "https://main--aem-boilerplate-commerce--hlxsites.aem.live/tools/picker/dist/index.html",
+      "isPalette": true,
+      "paletteRect": "top: 54px; left: 5px; bottom: 5px; width: 300px; height: calc(100% - 59px); border-radius: var(--hlx-sk-button-border-radius); overflow: hidden; resize: horizontal;"
+    }
+  ]
 }


### PR DESCRIPTION
Disable document authoring / Revert to file storage mode

file/content will be now again done on the drive:
https://drive.google.com/drive/folders/1jB3TTvp0O_J-SnnHyc5ktkPJpsPv7OnV

instead of the document authoring page:
https://da.live/#/atf-z/atf-aem-test